### PR TITLE
feat: consumer commits offsets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,14 +1882,17 @@ name = "streamit"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bilrost",
  "fluvio",
+ "fluvio-protocol",
  "futures",
  "serde",
  "time",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
 ]
 
 [[package]]
@@ -2159,6 +2162,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1888,6 +1888,7 @@ dependencies = [
  "fluvio-protocol",
  "futures",
  "serde",
+ "thiserror 2.0.11",
  "time",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,14 @@ members = ["crates/bin/streamit"]
 
 [workspace.dependencies]
 anyhow = { version = "1" }
+async-trait = "0"
 bilrost = "0"
 chrono = "0"
 fluvio = "0"
+fluvio-protocol = "0"
 futures = "0"
 serde = { version = "1", default-features = false, features = ["derive"] }
+thiserror = "2"
 time = { version = "0", features = ["serde", "parsing", "formatting", "macros"] }
 tokio = { version = "1",  default-features = false, features = ["full", "tracing", "macros", "time"] }
 tracing = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tracing-subscriber = {version = "0", features = ["env-filter"]}
 [profile.dev]
 opt-level = 0 # Disable optimizations and reduce the compile time
 split-debuginfo = "unpacked" # improve compilation performance by using unpacked debug symbols
+debug=true
 
 [profile.release]
 lto = false # Disable link-time optimization to reduce build time

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ fluvio topic create myio --retention-time '7 days' --segment-size '5 Ki' --max-p
 fluvio topic list
 ```
 
-Run the solution locally with [bacon](https://github.com/Canop/bacon) by executing `bacon`. Enter 'p' in Bacon to run the producer and enter 'c' to run the consumer.
+Run the solution locally with [bacon](https://github.com/Canop/bacon) by executing `bacon`. Enter 'p' in Bacon to run the producer and enter 'c' to run the consumer. Enter 't' in Bacon to run the test suite with [cargo-nextest](https://nexte.st). 

--- a/bacon.toml
+++ b/bacon.toml
@@ -12,7 +12,7 @@ command = [
   "--verbose",
   "--hide-progress-bar",
   "--failure-output",
-  "final", # or immediate
+  "immediate", # or immediate
   "--success-output",
   "immediate",
 ]

--- a/bacon.toml
+++ b/bacon.toml
@@ -2,19 +2,19 @@ default_job = "run-producer"
 env.CARGO_TERM_COLOR = "always"
 
 [jobs.test]
+clear = false # Keep output on screen
+display = "always" # Ensure output is displayed
 command = [
   "cargo",
   "+nightly",
   "nextest",
   "run",
-  "-Zcodegen-backend",
   "--all-features",
   "--verbose",
-  "--hide-progress-bar",
   "--failure-output",
-  "immediate", # or immediate
+  "final", # or final
   "--success-output",
-  "immediate",
+  "final",
 ]
 
 [keybindings]

--- a/crates/bin/streamit/Cargo.toml
+++ b/crates/bin/streamit/Cargo.toml
@@ -11,12 +11,13 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
-async-trait = "0.1.86"
+async-trait.workspace = true
 bilrost.workspace = true
 fluvio.workspace = true
-fluvio-protocol = "0.12.0"
+fluvio-protocol.workspace = true
 futures.workspace = true
 serde.workspace=true
+thiserror.workspace=true
 time.workspace=true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/bin/streamit/Cargo.toml
+++ b/crates/bin/streamit/Cargo.toml
@@ -11,14 +11,17 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
+async-trait = "0.1.86"
 bilrost.workspace = true
 fluvio.workspace = true
+fluvio-protocol = "0.12.0"
 futures.workspace = true
 serde.workspace=true
 time.workspace=true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+tracing-test = "0.2.5"
 
 [[bin]]
 name = "producer"

--- a/crates/bin/streamit/src/consumer.rs
+++ b/crates/bin/streamit/src/consumer.rs
@@ -1,0 +1,40 @@
+use async_trait::async_trait;
+use fluvio::{
+  consumer::{ConsumerConfigExtBuilder, ConsumerStream, Record as ConsumerRecord},
+  Fluvio, Offset,
+};
+use fluvio_protocol::link::ErrorCode;
+use std::pin::Pin;
+
+#[async_trait]
+pub trait Consumer: Send + Sync {
+  async fn consume(
+    &self,
+    topic: &str,
+    offset: Offset,
+  ) -> std::result::Result<Pin<Box<dyn ConsumerStream<Item = Result<ConsumerRecord, ErrorCode>> + Send>>, anyhow::Error>;
+}
+
+pub struct FluvioConsumer {}
+
+#[async_trait]
+impl Consumer for FluvioConsumer {
+  async fn consume(
+    &self,
+    topic: &str,
+    offset: Offset,
+  ) -> Result<Pin<Box<dyn ConsumerStream<Item = Result<ConsumerRecord, ErrorCode>> + Send>>, anyhow::Error> {
+    Ok(Box::pin(
+      Fluvio::connect()
+        .await?
+        .consumer_with_config(
+          ConsumerConfigExtBuilder::default()
+            .topic(topic)
+            .partition(0)
+            .offset_start(offset)
+            .build()?,
+        )
+        .await?,
+    ))
+  }
+}

--- a/crates/bin/streamit/src/lib.rs
+++ b/crates/bin/streamit/src/lib.rs
@@ -1,6 +1,5 @@
 #[allow(clippy::missing_errors_doc)]
 //
-//
 pub mod configure_tracing;
 pub mod message;
 pub mod topic;

--- a/crates/bin/streamit/src/main_consumer.rs
+++ b/crates/bin/streamit/src/main_consumer.rs
@@ -1,13 +1,10 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use bilrost::BorrowedMessage;
-use fluvio::{
-  consumer::{ConsumerConfigExtBuilder, ConsumerStream, Record as ConsumerRecord},
-  Fluvio, Offset,
-};
-use fluvio_protocol::link::ErrorCode;
+use consumer::{Consumer, FluvioConsumer};
+use fluvio::{consumer::Record as ConsumerRecord, Offset};
 use futures::StreamExt;
-use std::{pin::Pin, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 use streamitlib::{
   configure_tracing::init,
   message::{MessageKind, MessageWrapper},
@@ -19,6 +16,9 @@ use tokio::{
   time::sleep,
 };
 use tracing::{debug, error, info, trace, warn};
+
+mod consumer;
+mod mock_consumer;
 
 #[tokio::main]
 async fn main() {
@@ -89,53 +89,16 @@ impl Pinger for RealPinger {
   }
 }
 
-#[async_trait]
-trait Consumer: Send + Sync {
-  async fn consume(
-    &self,
-    topic: &str,
-    offset: Offset,
-  ) -> std::result::Result<Pin<Box<dyn ConsumerStream<Item = Result<ConsumerRecord, ErrorCode>> + Send>>, anyhow::Error>;
-}
-
-struct FluvioConsumer {}
-
-#[async_trait]
-impl Consumer for FluvioConsumer {
-  async fn consume(
-    &self,
-    topic: &str,
-    offset: Offset,
-  ) -> Result<Pin<Box<dyn ConsumerStream<Item = Result<ConsumerRecord, ErrorCode>> + Send>>, anyhow::Error> {
-    Ok(Box::pin(
-      Fluvio::connect()
-        .await?
-        .consumer_with_config(
-          ConsumerConfigExtBuilder::default()
-            .topic(topic)
-            .partition(0)
-            .offset_start(offset)
-            .build()?,
-        )
-        .await?,
-    ))
-  }
-}
-
 async fn receiver(
   tx: &Sender<ConsumerRecord>,
   pinger: &(impl Pinger + ?Sized),
   consumer: Arc<impl Consumer + ?Sized>,
 ) -> anyhow::Result<()> {
   // TODO commit offset and set consumer name https://github.com/infinyon/fluvio/blob/master/rfc/offset-management.md
-  trace!("Starting to consume");
 
   let mut stream = consumer.clone().consume(MYIO_TOPIC, Offset::beginning()).await.unwrap();
 
-  trace!("Waiting for messages");
-
   while let Some(msg) = stream.next().await {
-    trace!("Received message");
     match msg {
       Ok(msg) => tx.send(msg).await.context("Failed to send to the mpsc channel")?,
       Err(e) => error!("{e:?}"),
@@ -178,13 +141,9 @@ async fn handle_signals() -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::mock_consumer::tests::MockConsumer;
   use bilrost::Message;
-  use fluvio_protocol::record::{Batch, Record, RecordData};
-  use futures::{stream, Stream};
-  use std::{
-    sync::atomic::{AtomicBool, Ordering},
-    task::ready,
-  };
+  use std::sync::atomic::{AtomicBool, Ordering};
   use streamitlib::message::Birth;
   use tracing_test::traced_test;
 
@@ -200,86 +159,6 @@ mod tests {
         self.called.store(true, Ordering::SeqCst);
       }
       "pong".to_string()
-    }
-  }
-
-  // Mock Consumer that emits a single message
-  #[derive(Clone)]
-  struct MockConsumer {
-    record_values: Vec<Record>,
-  }
-
-  impl MockConsumer {
-    fn new(record_values: Vec<impl Into<RecordData>>) -> Self {
-      Self {
-        record_values: record_values
-          .into_iter()
-          .map(|record_value| Record::new(record_value.into()))
-          .collect(),
-      }
-    }
-  }
-
-  #[async_trait]
-  impl Consumer for MockConsumer {
-    async fn consume(
-      &self,
-      _topic: &str,
-      _offset: Offset,
-    ) -> Result<Pin<Box<dyn ConsumerStream<Item = Result<ConsumerRecord, ErrorCode>> + Send>>, anyhow::Error> {
-      info!("MockConsumer::consume");
-
-      let mut batch = Batch::new();
-      self
-        .record_values
-        .iter()
-        .for_each(|record| batch.add_record(record.clone()));
-
-      // we could also do this if we change &self to &mut self and pass the consumer around as
-      // Arc<Mutex<dyn Consumer> so that we have a mutable self.record_values
-      // batch.add_records(&mut self.record_values);
-
-      let stream = SinglePartitionConsumerStream {
-        // inner: stream::iter(vec![Ok(record)]),
-        inner: stream::iter(batch.into_consumer_records_iter(0).map(Ok)),
-      };
-      Ok(Box::pin(stream))
-    }
-  }
-
-  pub struct SinglePartitionConsumerStream<T> {
-    inner: T,
-  }
-
-  impl<T: Stream<Item = Result<ConsumerRecord, ErrorCode>> + Unpin> ConsumerStream for SinglePartitionConsumerStream<T> {
-    fn offset_commit(&mut self) -> std::result::Result<(), ErrorCode> {
-      todo!()
-    }
-
-    fn offset_flush(&mut self) -> futures::future::BoxFuture<'_, std::result::Result<(), ErrorCode>> {
-      todo!()
-    }
-  }
-
-  impl<T: Stream<Item = Result<ConsumerRecord, ErrorCode>> + Unpin> Stream for SinglePartitionConsumerStream<T> {
-    type Item = Result<ConsumerRecord, ErrorCode>;
-
-    fn poll_next(
-      self: std::pin::Pin<&mut Self>,
-      cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-      let self_mut = self.get_mut();
-      let pinned = std::pin::pin!(&mut self_mut.inner);
-      match ready!(pinned.poll_next(cx)) {
-        Some(Ok(last)) => {
-          trace!("LAST");
-          std::task::Poll::Ready(Some(Ok(last)))
-        }
-        other => {
-          trace!("OTHER");
-          std::task::Poll::Ready(other)
-        }
-      }
     }
   }
 

--- a/crates/bin/streamit/src/main_consumer.rs
+++ b/crates/bin/streamit/src/main_consumer.rs
@@ -1,11 +1,13 @@
-use anyhow::Context;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
 use bilrost::BorrowedMessage;
 use fluvio::{
-  consumer::{ConsumerConfigExtBuilder, Record},
+  consumer::{ConsumerConfigExtBuilder, ConsumerStream, Record as ConsumerRecord},
   Fluvio, Offset,
 };
+use fluvio_protocol::link::ErrorCode;
 use futures::StreamExt;
-use std::time::Duration;
+use std::{pin::Pin, sync::Arc, time::Duration};
 use streamitlib::{
   configure_tracing::init,
   message::{MessageKind, MessageWrapper},
@@ -21,22 +23,27 @@ use tracing::{debug, error, info, trace, warn};
 #[tokio::main]
 async fn main() {
   _ = init();
-  info!("Starting Consumer");
-  _ = consumer().await.inspect_err(|e| {
-    error!("Unexpected error: {:?}", e);
-  });
+  _ = main_consumer(Arc::new(RealPinger), Arc::new(FluvioConsumer {}))
+    .await
+    .inspect_err(|e| {
+      error!("Unexpected error: {:?}", e);
+    });
 }
 
-async fn consumer() -> anyhow::Result<()> {
+async fn main_consumer(pinger: Arc<dyn Pinger>, consumer: Arc<dyn Consumer>) -> Result<()> {
+  info!("Starting consumer");
   let (tx, mut rx) = mpsc::channel(100);
 
+  let pinger = pinger.clone();
+  let consumer = consumer.clone();
+
   let mut ingest_task = tokio::spawn(async move {
-    loop {
-      if let Err(e) = receiver(&tx).await {
-        warn!("receiver error: {e:?}");
-        sleep(Duration::from_secs(2)).await;
-      }
+    // loop {
+    if let Err(e) = receiver(&tx, &*pinger, consumer).await {
+      warn!("receiver error: {e:?}");
+      sleep(Duration::from_secs(2)).await;
     }
+    // }
   });
 
   let mut recv_task = tokio::spawn(async move {
@@ -47,7 +54,9 @@ async fn consumer() -> anyhow::Result<()> {
                 debug!("Failed to handle message: {:?}", e);
               });
           }
+
           () = sleep(Duration::from_secs(10)) => trace!("No new messages after 10s"),
+
           _ = handle_signals() => {
               break;
           }
@@ -60,32 +69,83 @@ async fn consumer() -> anyhow::Result<()> {
       _ = (&mut ingest_task) => ingest_task.abort(),
       _ = (&mut recv_task) => recv_task.abort(),
   };
+  sleep(Duration::from_secs(1)).await;
 
   Ok(())
 }
 
-async fn receiver(tx: &Sender<Record>) -> anyhow::Result<()> {
-  let fluvio = Fluvio::connect().await?;
-  let mut stream = fluvio
-    .consumer_with_config(
-      ConsumerConfigExtBuilder::default()
-        .topic(MYIO_TOPIC)
-        .partition(0)
-        // TODO store last processed offset in a topic
-        .offset_start(Offset::beginning())
-        .build()?,
-    )
-    .await?;
+#[async_trait]
+trait Pinger: Send + Sync {
+  async fn ping(&self, arg: &str) -> String;
+}
+
+#[derive(Copy, Clone)]
+struct RealPinger;
+
+#[async_trait]
+impl Pinger for RealPinger {
+  async fn ping(&self, _arg1: &str) -> String {
+    String::from("pong")
+  }
+}
+
+#[async_trait]
+trait Consumer: Send + Sync {
+  async fn consume(
+    &self,
+    topic: &str,
+    offset: Offset,
+  ) -> std::result::Result<Pin<Box<dyn ConsumerStream<Item = Result<ConsumerRecord, ErrorCode>> + Send>>, anyhow::Error>;
+}
+
+struct FluvioConsumer {}
+
+#[async_trait]
+impl Consumer for FluvioConsumer {
+  async fn consume(
+    &self,
+    topic: &str,
+    offset: Offset,
+  ) -> Result<Pin<Box<dyn ConsumerStream<Item = Result<ConsumerRecord, ErrorCode>> + Send>>, anyhow::Error> {
+    Ok(Box::pin(
+      Fluvio::connect()
+        .await?
+        .consumer_with_config(
+          ConsumerConfigExtBuilder::default()
+            .topic(topic)
+            .partition(0)
+            .offset_start(offset)
+            .build()?,
+        )
+        .await?,
+    ))
+  }
+}
+
+async fn receiver(
+  tx: &Sender<ConsumerRecord>,
+  pinger: &(impl Pinger + ?Sized),
+  consumer: Arc<impl Consumer + ?Sized>,
+) -> anyhow::Result<()> {
+  // TODO commit offset and set consumer name https://github.com/infinyon/fluvio/blob/master/rfc/offset-management.md
+  trace!("Starting to consume");
+
+  let mut stream = consumer.clone().consume(MYIO_TOPIC, Offset::beginning()).await.unwrap();
+
+  trace!("Waiting for messages");
+
   while let Some(msg) = stream.next().await {
+    trace!("Received message");
     match msg {
       Ok(msg) => tx.send(msg).await.context("Failed to send to the mpsc channel")?,
       Err(e) => error!("{e:?}"),
     }
   }
+  pinger.ping("ping").await;
   Ok(())
 }
 
-fn handle_message(record: &Record) -> anyhow::Result<()> {
+fn handle_message(record: &ConsumerRecord) -> anyhow::Result<()> {
   let data = record.value();
   let wrapper = MessageWrapper::decode_borrowed(data).context("Failed to decode message")?;
 
@@ -113,4 +173,134 @@ async fn handle_signals() -> anyhow::Result<()> {
   };
 
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use bilrost::Message;
+  use fluvio_protocol::record::{Batch, Record, RecordData};
+  use futures::{stream, Stream};
+  use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    task::ready,
+  };
+  use streamitlib::message::Birth;
+  use tracing_test::traced_test;
+
+  // Mock Pinger that tracks calls
+  struct MockPinger {
+    called: Arc<AtomicBool>,
+  }
+
+  #[async_trait]
+  impl Pinger for MockPinger {
+    async fn ping(&self, arg: &str) -> String {
+      if arg == "ping" {
+        self.called.store(true, Ordering::SeqCst);
+      }
+      "pong".to_string()
+    }
+  }
+
+  // Mock Consumer that emits a single message
+  #[derive(Clone)]
+  struct MockConsumer {
+    record_values: Vec<Record>,
+  }
+
+  impl MockConsumer {
+    fn new(record_values: Vec<impl Into<RecordData>>) -> Self {
+      Self {
+        record_values: record_values
+          .into_iter()
+          .map(|record_value| Record::new(record_value.into()))
+          .collect(),
+      }
+    }
+  }
+
+  #[async_trait]
+  impl Consumer for MockConsumer {
+    async fn consume(
+      &self,
+      _topic: &str,
+      _offset: Offset,
+    ) -> Result<Pin<Box<dyn ConsumerStream<Item = Result<ConsumerRecord, ErrorCode>> + Send>>, anyhow::Error> {
+      info!("MockConsumer::consume");
+
+      let mut batch = Batch::new();
+      self
+        .record_values
+        .iter()
+        .for_each(|record| batch.add_record(record.clone()));
+
+      // we could also do this if we change &self to &mut self and pass the consumer around as
+      // Arc<Mutex<dyn Consumer> so that we have a mutable self.record_values
+      // batch.add_records(&mut self.record_values);
+
+      let stream = SinglePartitionConsumerStream {
+        // inner: stream::iter(vec![Ok(record)]),
+        inner: stream::iter(batch.into_consumer_records_iter(0).map(Ok)),
+      };
+      Ok(Box::pin(stream))
+    }
+  }
+
+  pub struct SinglePartitionConsumerStream<T> {
+    inner: T,
+  }
+
+  impl<T: Stream<Item = Result<ConsumerRecord, ErrorCode>> + Unpin> ConsumerStream for SinglePartitionConsumerStream<T> {
+    fn offset_commit(&mut self) -> std::result::Result<(), ErrorCode> {
+      todo!()
+    }
+
+    fn offset_flush(&mut self) -> futures::future::BoxFuture<'_, std::result::Result<(), ErrorCode>> {
+      todo!()
+    }
+  }
+
+  impl<T: Stream<Item = Result<ConsumerRecord, ErrorCode>> + Unpin> Stream for SinglePartitionConsumerStream<T> {
+    type Item = Result<ConsumerRecord, ErrorCode>;
+
+    fn poll_next(
+      self: std::pin::Pin<&mut Self>,
+      cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+      let self_mut = self.get_mut();
+      let pinned = std::pin::pin!(&mut self_mut.inner);
+      match ready!(pinned.poll_next(cx)) {
+        Some(Ok(last)) => {
+          trace!("LAST");
+          std::task::Poll::Ready(Some(Ok(last)))
+        }
+        other => {
+          trace!("OTHER");
+          std::task::Poll::Ready(other)
+        }
+      }
+    }
+  }
+
+  #[traced_test]
+  #[tokio::test]
+  async fn test_consumer_calls_ping() {
+    let called = Arc::new(AtomicBool::new(false));
+    let pinger = Arc::new(MockPinger { called: called.clone() });
+
+    let consumer_mock = Arc::new(MockConsumer::new(vec![MessageWrapper::from(Birth::new(
+      "AliceMOCK".to_owned(),
+    ))
+    .encode_to_bytes()]));
+
+    let _ = main_consumer(pinger, consumer_mock).await;
+
+    assert!(logs_contain("Received Birth"));
+
+    assert!(
+      called.load(Ordering::SeqCst),
+      "Expected Pinger::ping to be called with 'ping'"
+    );
+  }
 }

--- a/crates/bin/streamit/src/main_producer.rs
+++ b/crates/bin/streamit/src/main_producer.rs
@@ -3,7 +3,7 @@ use bilrost::Message;
 use fluvio::RecordKey;
 use streamitlib::{
   configure_tracing::init,
-  message::{Birth, MessageKind, MessageWrapper},
+  message::{Birth, MessageWrapper},
   topic::MYIO_TOPIC,
 };
 use tracing::{debug, error, info};
@@ -20,10 +20,7 @@ async fn main() {
 async fn producer() -> anyhow::Result<()> {
   let birth = Birth::new("Alice".to_owned());
   let msg = format!("Message sent to Fluvio: {birth:?}");
-
-  let wrapper = MessageWrapper {
-    kind: MessageKind::Birth(birth),
-  };
+  let wrapper = MessageWrapper::from(birth);
 
   let producer = fluvio::producer(MYIO_TOPIC)
     .await

--- a/crates/bin/streamit/src/main_producer.rs
+++ b/crates/bin/streamit/src/main_producer.rs
@@ -12,9 +12,9 @@ use tracing::{debug, error, info};
 async fn main() {
   _ = init();
   info!("Starting Producer");
-  _ = producer().await.inspect_err(|e| {
+  if let Err(e) = producer().await {
     error!("Unexpected error: {:?}", e);
-  });
+  }
 }
 
 async fn producer() -> anyhow::Result<()> {

--- a/crates/bin/streamit/src/message.rs
+++ b/crates/bin/streamit/src/message.rs
@@ -12,6 +12,14 @@ pub struct MessageWrapper {
   pub kind: MessageKind,
 }
 
+impl From<Birth> for MessageWrapper {
+  fn from(birth: Birth) -> Self {
+    Self {
+      kind: MessageKind::Birth(birth),
+    }
+  }
+}
+
 #[derive(Debug, Eq, Clone, Oneof, PartialEq)]
 // #[bilrost(distinguished)]
 pub enum MessageKind {

--- a/crates/bin/streamit/src/message.rs
+++ b/crates/bin/streamit/src/message.rs
@@ -8,8 +8,17 @@ use time::OffsetDateTime;
 #[derive(Debug, Clone, Eq, Message, PartialEq)]
 // #[bilrost(distinguished)]
 pub struct MessageWrapper {
-  #[bilrost(oneof(100, 101))]
+  #[bilrost(oneof(100, 101, 102))]
   pub kind: MessageKind,
+}
+
+impl MessageWrapper {
+  #[must_use]
+  pub fn new_close_server() -> Self {
+    Self {
+      kind: MessageKind::CloseConsumers(String::from("Server is closing")),
+    }
+  }
 }
 
 impl From<Birth> for MessageWrapper {
@@ -28,6 +37,8 @@ pub enum MessageKind {
   Birth(Birth),
   #[bilrost(101)]
   Marriage(String),
+  #[bilrost(102)]
+  CloseConsumers(String),
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Message)]

--- a/crates/bin/streamit/src/mock_consumer.rs
+++ b/crates/bin/streamit/src/mock_consumer.rs
@@ -1,0 +1,84 @@
+#[cfg(test)]
+pub mod tests {
+  use crate::consumer::Consumer;
+  use async_trait::async_trait;
+  use fluvio::consumer::Record as ConsumerRecord;
+  use fluvio::{consumer::ConsumerStream, Offset};
+  use fluvio_protocol::link::ErrorCode;
+  use fluvio_protocol::record::{Batch, Record, RecordData};
+  use futures::{stream, Stream};
+  use std::pin::Pin;
+  use std::task::ready;
+
+  // Mock Consumer that emits a single message
+  #[derive(Clone)]
+  pub struct MockConsumer {
+    record_values: Vec<Record>,
+  }
+
+  impl MockConsumer {
+    pub fn new(record_values: Vec<impl Into<RecordData>>) -> Self {
+      Self {
+        record_values: record_values
+          .into_iter()
+          .map(|record_value| Record::new(record_value.into()))
+          .collect(),
+      }
+    }
+  }
+
+  #[async_trait]
+  impl Consumer for MockConsumer {
+    async fn consume(
+      &self,
+      _topic: &str,
+      _offset: Offset,
+    ) -> Result<Pin<Box<dyn ConsumerStream<Item = Result<ConsumerRecord, ErrorCode>> + Send>>, anyhow::Error> {
+      let mut batch = Batch::new();
+      self
+        .record_values
+        .iter()
+        .for_each(|record| batch.add_record(record.clone()));
+
+      // we could also do this if we change &self to &mut self and pass the consumer around as
+      // Arc<Mutex<dyn Consumer> so that we have a mutable self.record_values
+      // batch.add_records(&mut self.record_values);
+
+      let stream = SinglePartitionConsumerStream {
+        // inner: stream::iter(vec![Ok(record)]),
+        inner: stream::iter(batch.into_consumer_records_iter(0).map(Ok)),
+      };
+      Ok(Box::pin(stream))
+    }
+  }
+
+  pub struct SinglePartitionConsumerStream<T> {
+    inner: T,
+  }
+
+  impl<T: Stream<Item = Result<ConsumerRecord, ErrorCode>> + Unpin> ConsumerStream for SinglePartitionConsumerStream<T> {
+    fn offset_commit(&mut self) -> std::result::Result<(), ErrorCode> {
+      todo!()
+    }
+
+    fn offset_flush(&mut self) -> futures::future::BoxFuture<'_, std::result::Result<(), ErrorCode>> {
+      todo!()
+    }
+  }
+
+  impl<T: Stream<Item = Result<ConsumerRecord, ErrorCode>> + Unpin> Stream for SinglePartitionConsumerStream<T> {
+    type Item = Result<ConsumerRecord, ErrorCode>;
+
+    fn poll_next(
+      self: std::pin::Pin<&mut Self>,
+      cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+      let self_mut = self.get_mut();
+      let pinned = std::pin::pin!(&mut self_mut.inner);
+      match ready!(pinned.poll_next(cx)) {
+        Some(Ok(last)) => std::task::Poll::Ready(Some(Ok(last))),
+        other => std::task::Poll::Ready(other),
+      }
+    }
+  }
+}

--- a/crates/bin/streamit/src/mock_consumer.rs
+++ b/crates/bin/streamit/src/mock_consumer.rs
@@ -2,7 +2,7 @@
 pub mod tests {
   use crate::consumer::Consumer;
   use async_trait::async_trait;
-  use fluvio::consumer::Record as ConsumerRecord;
+  use fluvio::consumer::{OffsetManagementStrategy, Record as ConsumerRecord};
   use fluvio::{consumer::ConsumerStream, Offset};
   use fluvio_protocol::link::ErrorCode;
   use fluvio_protocol::record::{Batch, Record, RecordData};
@@ -32,7 +32,9 @@ pub mod tests {
     async fn consume(
       &self,
       _topic: &str,
-      _offset: Offset,
+      _consumer_name: &str,
+      _offset_strategry: OffsetManagementStrategy,
+      _offset_start: Offset,
     ) -> Result<Pin<Box<dyn ConsumerStream<Item = Result<ConsumerRecord, ErrorCode>> + Send>>, anyhow::Error> {
       let mut batch = Batch::new();
       self
@@ -58,11 +60,11 @@ pub mod tests {
 
   impl<T: Stream<Item = Result<ConsumerRecord, ErrorCode>> + Unpin> ConsumerStream for SinglePartitionConsumerStream<T> {
     fn offset_commit(&mut self) -> std::result::Result<(), ErrorCode> {
-      todo!()
+      Ok(())
     }
 
     fn offset_flush(&mut self) -> futures::future::BoxFuture<'_, std::result::Result<(), ErrorCode>> {
-      todo!()
+      Box::pin(async { Ok(()) })
     }
   }
 


### PR DESCRIPTION
- commit offsets to make sure that the consumer processes messages from the correct offset at startup
- Improved test coverage of the consumer logic, mock the fluvio consumer