### PR TITLE
simple bilrost usability

### DIFF
--- a/crates/bin/streamit/src/main_producer.rs
+++ b/crates/bin/streamit/src/main_producer.rs
@@ -3,7 +3,7 @@ use bilrost::Message;
 use fluvio::RecordKey;
 use streamitlib::{
   configure_tracing::init,
-  message::{Birth, MessageWrapper},
+  message::{Birth, StreamMessage},
   topic::MYIO_TOPIC,
 };
 use tracing::{debug, error, info};
@@ -20,21 +20,20 @@ async fn main() {
 
 async fn producer() -> anyhow::Result<()> {
   let birth = Birth::new("Alice".to_owned());
-  let msg = format!("Message sent to Fluvio: {birth:?}");
-  let wrapper = MessageWrapper::from(birth);
+  let msg = StreamMessage::from(birth.clone());
 
   let producer = fluvio::producer(MYIO_TOPIC)
     .await
     .context("Failed to create producer")?;
 
   producer
-    .send(RecordKey::NULL, wrapper.encode_to_bytes())
+    .send(RecordKey::NULL, msg.encode_to_bytes())
     // or send a record with a key:
     // .send(nanoid::nanoid!(8), encoded)
     .await
     .context("Failed to send message")?;
 
   producer.flush().await.context("Failed to flush producer")?;
-  debug!(msg);
+  debug!("Message sent to Fluvio: {birth:?}");
   Ok(())
 }


### PR DESCRIPTION
this just simplifies the `bilrost` code, since it's possible to derive `Message` for a oneof enum which will then act as a message which only has those fields. This turns out to be a pretty common case, and eliminating the need for the wrapper makes things a lot simpler.